### PR TITLE
PUBLISH support

### DIFF
--- a/src/main/java/io/kestra/plugin/redis/AbstractRedisConnection.java
+++ b/src/main/java/io/kestra/plugin/redis/AbstractRedisConnection.java
@@ -67,6 +67,14 @@ public abstract class AbstractRedisConnection extends Task implements RedisConne
             return syncCommands.lpop(key, count);
         }
 
+        public long publish(String channel, List<String> values) {
+            long result = 0;
+            for (String value : values) {
+                result += syncCommands.publish(channel, value);
+            }
+            return result;
+        }
+
         public void close() {
             this.redisConnection.close();
             this.redisClient.shutdown();

--- a/src/main/java/io/kestra/plugin/redis/Publish.java
+++ b/src/main/java/io/kestra/plugin/redis/Publish.java
@@ -1,0 +1,122 @@
+package io.kestra.plugin.redis;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.plugin.redis.models.SerdeType;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotNull;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Publish one or multiple values to a channel"
+)
+@Plugin(
+    examples = {
+        @Example(
+            code = {
+                "url: redis://:redis@localhost:6379/0",
+                "channel: mych",
+                "from:",
+                "   - value1",
+                "   - value2"
+            }
+        )
+    }
+)
+public class Publish extends AbstractRedisConnection implements RunnableTask<Publish.Output> {
+    @Schema(
+        title = "The redis channel to publish."
+    )
+    @NotNull
+    @PluginProperty(dynamic = true)
+    private String channel;
+
+    @Schema(
+        title = "The list of value to publish to the channel"
+    )
+    @NotNull
+    @PluginProperty(dynamic = true)
+    private Object from;
+
+    @Builder.Default
+    private SerdeType serdeType = SerdeType.STRING;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        try (RedisFactory factory = this.redisFactory(runContext)) {
+
+            Integer count = 0;
+            if (this.from instanceof String || this.from instanceof List) {
+                Flowable<Object> flowable;
+                Flowable<Integer> resultFlowable;
+                if (this.from instanceof String) {
+                    URI from = new URI(runContext.render((String) this.from));
+                    try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.uriToInputStream(from)))) {
+                        flowable = Flowable.create(FileSerde.reader(inputStream), BackpressureStrategy.BUFFER);
+                        resultFlowable = this.buildFlowable(flowable, runContext, factory);
+
+                        count = resultFlowable
+                            .reduce(Integer::sum)
+                            .blockingGet();
+                    }
+                } else {
+                    flowable = Flowable.fromArray(((List<Object>) this.from).toArray());
+                    resultFlowable = this.buildFlowable(flowable, runContext, factory);
+
+                    count = resultFlowable
+                        .reduce(Integer::sum)
+                        .blockingGet();
+                    runContext.metric(Counter.of("records", count));
+                }
+            }
+
+            Output output = Output.builder().count(count).build();
+
+            factory.close();
+
+            return output;
+        }
+    }
+
+    private Flowable<Integer> buildFlowable(Flowable<Object> flowable, RunContext runContext, RedisFactory factory) {
+        return flowable
+            .map(row -> {
+                factory.publish(
+                    runContext.render(channel),
+                    Collections.singletonList(serdeType.serialize(String.valueOf(row)))
+                );
+
+                return 1;
+            });
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "Count",
+            description = "The number of value published"
+        )
+        private Integer count;
+    }
+}

--- a/src/test/java/io/kestra/plugin/redis/PublishTest.java
+++ b/src/test/java/io/kestra/plugin/redis/PublishTest.java
@@ -1,0 +1,92 @@
+package io.kestra.plugin.redis;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PublishTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    protected StorageInterface storageInterface;
+
+    private static final String REDIS_URI = "redis://:redis@localhost:6379/0";
+
+    @Test
+    void testPublishAsList() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Publish task = Publish.builder()
+            .url(REDIS_URI)
+            .channel("mych")
+            .from(Arrays.asList("value1", "value2"))
+            .build();
+
+        Publish.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getCount(), is(2));
+    }
+
+    @Test
+    void testPublishAsFile() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        URI uri = createTestFile();
+
+        Publish task = Publish.builder()
+            .url(REDIS_URI)
+            .channel("mychFile")
+            .from(uri.toString())
+            .build();
+
+        Publish.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getCount(), is(5));
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+        Delete.builder()
+            .url(REDIS_URI)
+            .keys(List.of("mych"))
+            .build().run(runContext);
+        Delete.builder()
+            .url(REDIS_URI)
+            .keys(List.of("mychFile"))
+            .build().run(runContext);
+    }
+
+    URI createTestFile() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = runContext.tempFile(".ion").toFile();
+        OutputStream output = new FileOutputStream(tempFile);
+        for (int i = 0; i < 5; i++) {
+            FileSerde.write(output, i);
+        }
+        return storageInterface.put(URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+    }
+}


### PR DESCRIPTION
PUBLISH is a very important aspect of using Redis pub/sub is missing.
It could be essential in orchestration ETL pipelines, for example:

source => kestra => redis queue => existing consumer

Implementation is based on the existing LPUSH