### PR TITLE
Rename id from 'keys-json' to 'redis-json'

### DIFF
--- a/src/test/resources/sanity-checks/redis-json.yaml
+++ b/src/test/resources/sanity-checks/redis-json.yaml
@@ -1,4 +1,4 @@
-id: keys-json
+id: redis-json
 namespace: sanitychecks.plugin-redis
 
 inputs:


### PR DESCRIPTION
Part of the issue https://github.com/kestra-io/sanity-checks/issues/21. 

First, the flow ID does not match the file name, plus, the existing ID is clashing with https://github.com/kestra-io/plugin-redis/blob/master/src/test/resources/sanity-checks/keys-json.yaml. 

Second, due to this, the flow is not getting added to the sanitycheck namespace, and the for loop is getting an error (as duplicate same IDs are not allowed in a namespace)