### PR TITLE
fix: return null when deserializing a null payload

### DIFF
--- a/src/main/java/io/kestra/plugin/redis/models/SerdeType.java
+++ b/src/main/java/io/kestra/plugin/redis/models/SerdeType.java
@@ -14,6 +14,9 @@ public enum SerdeType {
     JSON;
 
     public Object deserialize(String payload) throws IOException {
+        if (payload == null) {
+            return null;
+        }
         if (this == SerdeType.JSON) {
             return JacksonMapper.ofJson(false).readValue(payload, Object.class);
         } else {

--- a/src/test/java/io/kestra/plugin/redis/string/GetTest.java
+++ b/src/test/java/io/kestra/plugin/redis/string/GetTest.java
@@ -57,7 +57,7 @@ class GetTest {
     }
 
     @Test
-    void testMissingGetFailed() throws Exception {
+    void testMissingGetFailed() {
         RunContext runContext = runContextFactory.of(Map.of());
 
         Get task = Get.builder()
@@ -69,6 +69,24 @@ class GetTest {
         NullPointerException e = Assertions.assertThrows(NullPointerException.class, () -> task.run(runContext));
 
         assertThat(e.getMessage(), is("Missing keys 'missing'"));
+    }
+
+    @Test
+    void testGetJsonOnNonExistentKeyDoesNotFail_WhenFailedOnMissingIsFalse() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+        String nonExistentKey = IdUtils.create();
+
+        Get task = Get.builder()
+            .url(Property.ofValue(REDIS_URI))
+            .key(Property.ofValue(nonExistentKey))
+            .serdeType(Property.ofValue(SerdeType.JSON))
+            .failedOnMissing(Property.ofValue(false))
+            .build();
+
+        Get.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getData(), is(nullValue()));
+        assertThat(runOutput.getKey(), is(nonExistentKey));
     }
 
     @Test


### PR DESCRIPTION
Null was throwing error even if "failedOnMissing=false"

Fixes #165


### QA

Running a Redis container with only one key "mykey". The following flow was on error before the fix and on success after


```yaml
id: redis_get
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.redis.string.Get
    key: mykeya
    serdeType: JSON
    url: redis://127.0.0.1:6379
    failedOnMissing: false
```

QA setup note : you can use following command to have an unsecured local Redis with Docker : `docker run -d \
--name my-redis \
-p 6379:6379 \
redis redis-server --protected-mode no --bind 0.0.0.0`