### PR TITLE
fix(plugin-redis-1): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/redis/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/redis/cli/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Redis CLI",
     description = "This sub-group of plugins contains tasks for running Redis CLI commands.",
     categories = PluginSubGroup.PluginCategory.DATA
 )

--- a/src/main/java/io/kestra/plugin/redis/json/package-info.java
+++ b/src/main/java/io/kestra/plugin/redis/json/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "JSON",
+    title = "Redis JSON",
     description = "This sub-group of plugins contains tasks for using the Redis NoSQL database JSON commands.",
     categories = {
         PluginSubGroup.PluginCategory.DATA

--- a/src/main/java/io/kestra/plugin/redis/list/package-info.java
+++ b/src/main/java/io/kestra/plugin/redis/list/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Redis List",
     description = "This sub-group of plugins contains tasks for using the Redis NoSQL database lists commands.",
     categories = {
         PluginSubGroup.PluginCategory.DATA

--- a/src/main/java/io/kestra/plugin/redis/pubsub/package-info.java
+++ b/src/main/java/io/kestra/plugin/redis/pubsub/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "PubSub",
+    title = "Redis PubSub",
     description = "This sub-group of plugins contains tasks for using the Redis NoSQL database pub/sub commands.",
     categories = {
         PluginSubGroup.PluginCategory.DATA

--- a/src/main/java/io/kestra/plugin/redis/string/package-info.java
+++ b/src/main/java/io/kestra/plugin/redis/string/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Redis String",
     description = "This sub-group of plugins contains tasks for using the Redis NoSQL database strings commands.",
     categories = {
         PluginSubGroup.PluginCategory.DATA


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge