### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.4.4-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/redis/list/ListPop.java
+++ b/src/main/java/io/kestra/plugin/redis/list/ListPop.java
@@ -101,7 +101,7 @@ public class ListPop extends AbstractRedisConnection implements RunnableTask<Lis
                 throw new IllegalArgumentException("maxDuration or maxRecords must be set to avoid infinite loop");
             }
 
-            try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+            try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
                 AtomicInteger total = new AtomicInteger();
                 ZonedDateTime started = ZonedDateTime.now();
 

--- a/src/main/java/io/kestra/plugin/redis/list/ListPush.java
+++ b/src/main/java/io/kestra/plugin/redis/list/ListPush.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.redis.list;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -113,7 +112,7 @@ public class ListPush extends AbstractRedisConnection implements RunnableTask<Li
 
             if (from instanceof String fromUrl) {
                 URI fromURI = new URI(runContext.render(fromUrl));
-                try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(fromURI)))) {
+                try (var inputStream = new BufferedInputStream(runContext.storage().getFile(fromURI), FileSerde.BUFFER_SIZE)) {
                     Flux<Object> flowable = FileSerde.readAll(inputStream);
                     Flux<Integer> resultFlowable = this.buildFlowable(flowable, runContext, factory);
                     count = resultFlowable.reduce(Integer::sum).blockOptional().orElse(0);

--- a/src/main/java/io/kestra/plugin/redis/pubsub/Publish.java
+++ b/src/main/java/io/kestra/plugin/redis/pubsub/Publish.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.redis.pubsub;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -100,7 +99,7 @@ public class Publish extends AbstractRedisConnection implements RunnableTask<Pub
             Integer count;
             if (this.from instanceof String fromStr) {
                 URI from = new URI(runContext.render(fromStr));
-                try (BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)))) {
+                try (var inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)) {
                     Flux<Object> flowable = FileSerde.readAll(inputStream);
                     Flux<Integer> resultFlowable = this.buildFlowable(flowable, runContext, factory);
                     count = resultFlowable.reduce(Integer::sum).blockOptional().orElse(0);

--- a/src/test/java/io/kestra/plugin/redis/list/ListPushTest.java
+++ b/src/test/java/io/kestra/plugin/redis/list/ListPushTest.java
@@ -1,10 +1,13 @@
 package io.kestra.plugin.redis.list;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -105,10 +108,25 @@ class ListPushTest {
         RunContext runContext = runContextFactory.of(Map.of());
 
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-        OutputStream output = new FileOutputStream(tempFile);
-        for (int i = 0; i < 5; i++) {
-            FileSerde.write(output, i);
+        try (OutputStream output = new FileOutputStream(tempFile)) {
+            for (int i = 0; i < 5; i++) {
+                FileSerde.write(output, i);
+            }
+            output.flush();
         }
-        return storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        // Read back ION from storage and assert count and content
+        try (InputStream is = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, uri), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(is, result::add);
+            assertThat(result.size(), is(5));
+            for (int i = 0; i < 5; i++) {
+                assertThat(result.get(i), is(i));
+            }
+        }
+
+        return uri;
     }
 }


### PR DESCRIPTION
## Summary
- Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility
- `BufferedReader`/`InputStreamReader` replaced with `BufferedInputStream` in `Publish.java` and `ListPush.java`
- `BufferedWriter`/`FileWriter` replaced with `BufferedOutputStream`/`FileOutputStream` in `ListPop.java`
- Bump `kestraVersion` from 1.3.13 to 1.3.19

Ref: kestra-io/kestra#3155