### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/src/test/resources/flows/realtime.yaml
+++ b/src/test/resources/flows/realtime.yaml
@@ -9,5 +9,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/src/test/resources/flows/trigger.yaml
+++ b/src/test/resources/flows/trigger.yaml
@@ -11,5 +11,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents